### PR TITLE
Fix fetch invoices type error

### DIFF
--- a/app/admin/dashboard/components/home/GlobalDashboard.tsx
+++ b/app/admin/dashboard/components/home/GlobalDashboard.tsx
@@ -25,7 +25,6 @@ import Invoices from "./Registration/Invoices";
 import InvoiceProducts from "./Registration/InvoiceProducts";
 import DetailInfo from "./Registration/DetailInfo";
 import StockPricing from "./Pricing/StockPricing";
-import { geteuid } from "process";
 
 const GlobalDashboard = () => {
   const [notification, setNotification] = useState<any>(null);

--- a/app/api/analytics/category-stats/route.ts
+++ b/app/api/analytics/category-stats/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import { getCategoryStats } from "@/app/actions/analyticsActions";

--- a/app/api/analytics/current-overview/route.ts
+++ b/app/api/analytics/current-overview/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import { getCurrentStockOverview } from "@/app/actions/analyticsActions";

--- a/app/api/analytics/daily-movements/route.ts
+++ b/app/api/analytics/daily-movements/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import { getDailyMovements } from "@/app/actions/analyticsActions";

--- a/app/api/analytics/monthly-summary/route.ts
+++ b/app/api/analytics/monthly-summary/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import { getMonthlySummary } from "@/app/actions/analyticsActions";

--- a/app/api/analytics/product-performance/route.ts
+++ b/app/api/analytics/product-performance/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import { getProductPerformance } from "@/app/actions/analyticsActions";

--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { getInvoiceProductByEmail, initialiseProductInvoice } from "@/app/actions/productActions";
 import { getCurrentUser } from "@/app/utils/authClient";

--- a/app/api/products/[Id]/productLines/[productLineId]/route.ts
+++ b/app/api/products/[Id]/productLines/[productLineId]/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import { deleteProductLine, updateProductLine } from "@/app/actions/productActions";

--- a/app/api/products/[Id]/productLines/route.ts
+++ b/app/api/products/[Id]/productLines/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/app/utils/authClient";
 import prisma from "@/app/lib/prisma";

--- a/app/api/products/[Id]/route.ts
+++ b/app/api/products/[Id]/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from 'next/server';
 import { getProductsById } from '@/app/actions/productActions';
 

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,3 +1,4 @@
+export const runtime = "nodejs";
 import { NextRequest, NextResponse } from "next/server";
 import { deleteProductInvoice, getInvoiceProductByEmail, initialiseProductInvoice } from "@/app/actions/productActions";
 import { getCurrentUser } from "@/app/utils/authClient";


### PR DESCRIPTION
Fixes "TypeError: Failed to fetch" by ensuring API routes run on Node.js runtime and removing a client-side Node.js import.

The "Failed to fetch" error was caused by Next.js API routes, which utilize Prisma and JWT, implicitly attempting to run on the unsupported Edge runtime. Explicitly setting `export const runtime = "nodejs";` for these routes forces them to use the Node.js runtime, resolving the underlying crash. Additionally, an unused Node.js-specific `process` import was removed from a client-side component to prevent potential browser-side issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-e236b5db-7e6e-4573-b6ea-559176f85db9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e236b5db-7e6e-4573-b6ea-559176f85db9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

