### PR TITLE
Fix dashboard data fetching errors

### DIFF
--- a/app/admin/dashboard/components/analytics/AnalyticsDashboard.tsx
+++ b/app/admin/dashboard/components/analytics/AnalyticsDashboard.tsx
@@ -98,7 +98,7 @@ const AnalyticsDashboard = () => {
           `/api/analytics/product-performance?startDate=${startDateStr}&endDate=${endDateStr}&limit=10`
         ).then((res) => res.json()),
         fetch(
-          `/api/analytics/current-overview?startDate=${startDate}&endDate=${endDate}`
+          `/api/analytics/current-overview?startDate=${encodeURIComponent(startDateStr)}&endDate=${encodeURIComponent(endDateStr)}`
         ).then((res) => res.json()),
       ]);
 

--- a/app/admin/dashboard/components/analytics/PrintReport.tsx
+++ b/app/admin/dashboard/components/analytics/PrintReport.tsx
@@ -242,9 +242,9 @@ const PDFReportLayout = React.forwardRef(
     const weeklyData = calculateWeeklyTotals(data.dailyMovements);
 
     // Handle monthly summary - check if it's an object or array
-    const monthlySummaryData = Array.isArray(data.monthlySummary)
-      ? data.monthlySummary
-      : [data.monthlySummary]; // Convert object to array for consistent rendering
+    const monthlySummaryData = data.monthlySummary
+      ? (Array.isArray(data.monthlySummary) ? data.monthlySummary : [data.monthlySummary])
+      : [];
 
     return (
       <div
@@ -340,9 +340,11 @@ const PDFReportLayout = React.forwardRef(
                 <tr key={index} className="border-b">
                   <td className="px-4 py-3">
                     <div className="text-sm font-medium">
-                      {monthNames[monthData.month - 1]} {monthData.year}
+                      {typeof monthData?.month === 'number' && monthData?.year
+                        ? `${monthNames[monthData.month - 1]} ${monthData.year}`
+                        : `${monthName} ${selectedYear}`}
                     </div>
-                    {!Array.isArray(data.monthlySummary) && (
+                    {data.monthlySummary && !Array.isArray(data.monthlySummary) && (
                       <div className="text-xs text-gray-500">
                         Données actuelles
                       </div>

--- a/app/admin/dashboard/components/home/GlobalDashboard.tsx
+++ b/app/admin/dashboard/components/home/GlobalDashboard.tsx
@@ -61,7 +61,7 @@ const fetchAnalysisData = async () => {
   try {
     const [currentOverview, productPerformance, getCategoryStats] =
       await Promise.all([
-        fetch(`/api/analytics/current-overview?startDate=${startDateStr}&endDate=${endDateStr}`).then((res) => res.json()),
+        fetch(`/api/analytics/current-overview?startDate=${encodeURIComponent(startDateStr)}&endDate=${encodeURIComponent(endDateStr)}`).then((res) => res.json()),
         fetch(
           `/api/analytics/product-performance?startDate=${startDateStr}&endDate=${endDateStr}&limit=10`
         ).then((res) => res.json()),

--- a/app/admin/dashboard/components/home/Registration/InvoiceProducts.tsx
+++ b/app/admin/dashboard/components/home/Registration/InvoiceProducts.tsx
@@ -86,7 +86,7 @@ const InvoiceProducts: React.FC<CompoInfo> = ({
           `/api/analytics/product-performance?startDate=${startDateStr}&endDate=${endDateStr}&limit=10`
         ).then((res) => res.json()),
         fetch(
-          `/api/analytics/current-overview?startDate=${startDate}&endDate=${endDate}`
+          `/api/analytics/current-overview?startDate=${encodeURIComponent(startDateStr)}&endDate=${encodeURIComponent(endDateStr)}`
         ).then((res) => res.json()),
       ]);
 

--- a/app/api/worker/route.ts
+++ b/app/api/worker/route.ts
@@ -57,5 +57,8 @@ export async function GET(request: NextRequest) {
     }));
 
     return NextResponse.json(invoices)
-  } catch (error) {}
+  } catch (error) {
+    console.error("/api/worker GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
 }

--- a/app/worker/dashboard/page.tsx
+++ b/app/worker/dashboard/page.tsx
@@ -166,7 +166,7 @@ const WorkerStockWorkspace = () => {
       invoice.id.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesFilter =
       filterCategory === "all" ||
-      invoice.productLines.some(
+      (invoice.products || invoice.productLines || []).some(
         (product) => product.category === filterCategory
       );
     return matchesSearch && matchesFilter;
@@ -179,7 +179,7 @@ const WorkerStockWorkspace = () => {
     }));
 
     const productName =
-      selectedInvoice?.products.find((p) => p.id === productId)?.name || "";
+      (selectedInvoice?.products || selectedInvoice?.productLines || []).find((p: any) => p.id === productId)?.name || "";
 
     setQuantityAndReason((prev) => ({
       ...prev,
@@ -203,7 +203,7 @@ const WorkerStockWorkspace = () => {
     }));
 
     const productName =
-      selectedInvoice?.products.find((p) => p.id === productId)?.name || "";
+      (selectedInvoice?.products || selectedInvoice?.productLines || []).find((p: any) => p.id === productId)?.name || "";
 
     setQuantityAndReason((prev) => ({
       ...prev,
@@ -377,7 +377,7 @@ const WorkerStockWorkspace = () => {
         ...data,
         reason: getFinalReasonForPrint(productId),
         unit:
-          selectedInvoice?.products.find((p) => p.id === productId)?.unit ||
+          (selectedInvoice?.products || selectedInvoice?.productLines || []).find((p: any) => p.id === productId)?.unit ||
           "unités",
       }));
   };


### PR DESCRIPTION
Fixes "Failed to fetch" errors in analytics and worker dashboards and a "Cannot read properties of null" error in the analytics report.

The "Failed to fetch" errors were due to incorrect date parameter formatting in analytics API calls and unhandled exceptions in the worker API route. The "Cannot read properties of null" error occurred because the monthly summary data in the PDF report was not null-checked. Additionally, product data access in the worker dashboard was normalized to handle both `products` and `productLines` fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5f4799b-e9e3-43e7-85c4-766549991851">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5f4799b-e9e3-43e7-85c4-766549991851">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

